### PR TITLE
Pass query strings through proxy

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -47,7 +47,9 @@ class LocalProxyHandler(IPythonHandler):
         body = self.request.body
         if not body: body = None
 
-        uri = self.proxy_uri + ':' + port + '/' + add_path
+        query_string = '?' + self.request.query if self.request.query else ''
+
+        uri = self.proxy_uri + ':' + port + '/' + add_path + query_string
 
         client = tornado.httpclient.AsyncHTTPClient()
 


### PR DESCRIPTION
In my testing, query string were being dropped, instead of being sent through to the proxy.  This change fixes things for me.

It's probably more complicated than strictly necessary (we could append '?' when the query string is empty), but it should keep the URLs as close as possible to their original form.