### PR TITLE
Support a lot more HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nbserverproxy
-Jupyter notebook server extension to proxy web services. This enables users to reach arbitrary web services running within their spawned Jupyter server and is probably most appropriate for services which can't readily be converted into extensions. GET and POST are supported.
+Jupyter notebook server extension to proxy web services. This enables users to reach arbitrary web services running within their spawned Jupyter server and is probably most appropriate for services which can't readily be converted into extensions.
 
 ## Example
 A user starts a web service via `New > Terminal`:

--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -10,7 +10,6 @@ from notebook.base.handlers import IPythonHandler
 
 
 class LocalProxyHandler(IPythonHandler):
-    SUPPORTED_METHODS = ['GET', 'POST']
     proxy_uri = "http://localhost"
 
     @web.authenticated
@@ -62,10 +61,26 @@ class LocalProxyHandler(IPythonHandler):
             if response.body:
                 self.write(response.body)
 
+    # support all the methods that torando does by default!
     def get(self, port, proxy_path=''):
         return self.proxy(port, proxy_path)
 
     def post(self, port, proxy_path=''):
+        return self.proxy(port, proxy_path)
+
+    def put(self, port, proxy_path=''):
+        return self.proxy(port, proxy_path)
+
+    def delete(self, port, proxy_path=''):
+        return self.proxy(port, proxy_path)
+
+    def head(self, port, proxy_path=''):
+        return self.proxy(port, proxy_path)
+
+    def patch(self, port, proxy_path=''):
+        return self.proxy(port, proxy_path)
+
+    def options(self, port, proxy_path=''):
         return self.proxy(port, proxy_path)
 
     def check_xsrf_cookie(self):

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ import setuptools
 
 setuptools.setup(
     name="nbserverproxy",
-    version='0.2.0',
+    version='0.3.0',
     url="https://github.com/jupyterhub/nbserverproxy",
     author="Ryan Lovett",
     author_email="rylo@berkeley.edu",
     license="BSD 3-Clause",
     description="Jupyter server extension to proxy web services",
     packages=setuptools.find_packages(),
-    install_requires=[ 'tornado', 'notebook' ],
+    install_requires=['notebook'],
     classifiers=[
         'Framework :: Jupyter',
     ]


### PR DESCRIPTION
I don't think there's any explicit reason for us to whitelist
methods.

Fixes #5 