### PR TITLE
Do not use None as body for POST requests

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -44,6 +44,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
         # super get is not async
         super().get(*args, **kwargs)
 
+
 class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     async def open(self, port, proxied_path):
         """
@@ -104,10 +105,12 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
             ws = WebSocketProxyHandler(*self._init_args, **self._init_kwargs)
             return await ws.get(port, proxied_path)
 
-
         body = self.request.body
         if not body:
-            body = None
+            if self.request.method == 'POST':
+                body = b''
+            else:
+                body = None
 
         client_uri = '{uri}:{port}{path}'.format(
             uri='http://localhost',


### PR DESCRIPTION
POST requests can not have None as body, so instead use an empty byte sequence.

I am actually not sure if this is the "right way" (tm) to fix this. Or what else this potentially breaks in terms of HTTP compliance.

Needs this to make https://github.com/betatim/openrefineder work. I think the real problem is that OpenRefine sends empty bodys for POST requests???