### PR TITLE
[MRG] Use MRO method to get base classes

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -3,6 +3,7 @@ Authenticated HTTP proxy for Jupyter Notebooks
 
 Some original inspiration from https://github.com/senko/tornado-proxy
 """
+import inspect
 import socket
 import os
 from tornado import gen, web, httpclient, httputil, process, websocket
@@ -17,7 +18,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
         super().__init__(*args, **kwargs)
         # since my parent doesn't keep calling the super() constructor,
         # I need to do it myself
-        bases = type(self).__bases__
+        bases = inspect.getmro(type(self))
         assert WebSocketHandlerMixin in bases
         meindex = bases.index(WebSocketHandlerMixin)
         try:


### PR DESCRIPTION
Using the `__bases__` attribute stops working if you have a class that inherits from a class that uses the `WebSocketMixin`. Instead use the `inspect` module to get the classes in the ["method resolution order"](https://docs.python.org/3/library/inspect.html#inspect.getmro).

I think this should be more robust. Though I am not sure why we do this trickery, seems a bit weird/smells wrong.

* [x] Before merging this we should move the import to the top.