### PR TITLE
Only choose subprotocol if subprotocol list is non-empty

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -59,7 +59,8 @@ def pingable_ws_connect(request=None, on_message_callback=None,
     else:
         conn = PingableWSClientConnection(request=request,
             on_message_callback=on_message_callback,
-            on_ping_callback=on_ping_callback)
+            on_ping_callback=on_ping_callback,
+            max_message_size=getattr(websocket, '_default_max_message_size', 10 * 1024 * 1024))
 
     return conn.connect_future
 
@@ -295,7 +296,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
     def select_subprotocol(self, subprotocols):
         '''Select a single Sec-WebSocket-Protocol during handshake.'''
-        if type(subprotocols) == list:
+        if isinstance(subprotocols, list) and subprotocols:
             self.log.info('Client sent subprotocols: {}'.format(subprotocols))
             return subprotocols[0]
         return super().select_subprotocol(subprotocols)


### PR DESCRIPTION
Addresses #39 to fix breaking change for websockets in Tornado 5.1

See http://www.tornadoweb.org/en/stable/releases/v5.1.0.html#tornado-websocket
> The WebSocketHandler.select_subprotocol method is now called with an empty list instead of a list containing an empty string if no subprotocols were requested by the client.