### PR TITLE
Allow users to connect to services on other hosts

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -99,7 +99,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
 
 
 class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
-    async def open(self, host='localhost', port, proxied_path=''):
+    async def open(self, host, port, proxied_path=''):
         """
         Called when a client opens a websocket connection.
 
@@ -108,6 +108,9 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         """
         if not proxied_path.startswith('/'):
             proxied_path = '/' + proxied_path
+
+        if not host:
+            host = 'localhost'
 
         client_uri = 'ws://{host}:{port}{path}'.format(
             host=host,
@@ -198,7 +201,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
 
     @web.authenticated
-    async def proxy(self, host='localhost', port, proxied_path):
+    async def proxy(self, host, port, proxied_path):
         '''
         While self.request.uri is
             (hub)    /user/username/proxy/([0-9]+)/something.
@@ -223,6 +226,9 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
                 body = b''
             else:
                 body = None
+
+        if not host:
+            host = 'localhost'
 
         client_uri = 'http://{host}:{port}{path}'.format(
             host=host,
@@ -467,7 +473,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 def setup_handlers(web_app):
     host_pattern = '.*$'
     web_app.add_handlers('.*', [
-        (url_path_join(web_app.settings['base_url'], r'/proxy/(?:([a-z0-9]+(?:[\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})/)?(\d+)(.*)'), LocalProxyHandler)
+        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler)
     ])
 
 # vim: set et ts=4 sw=4:

--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -99,7 +99,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
 
 
 class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
-    async def open(self, port, proxied_path=''):
+    async def open(self, host='localhost', port, proxied_path=''):
         """
         Called when a client opens a websocket connection.
 
@@ -109,8 +109,8 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         if not proxied_path.startswith('/'):
             proxied_path = '/' + proxied_path
 
-        client_uri = '{uri}:{port}{path}'.format(
-            uri='ws://127.0.0.1',
+        client_uri = 'ws://{host}:{port}{path}'.format(
+            host=host,
             port=port,
             path=proxied_path
         )
@@ -198,7 +198,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
 
     @web.authenticated
-    async def proxy(self, port, proxied_path):
+    async def proxy(self, host='localhost', port, proxied_path):
         '''
         While self.request.uri is
             (hub)    /user/username/proxy/([0-9]+)/something.
@@ -224,8 +224,8 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
             else:
                 body = None
 
-        client_uri = '{uri}:{port}{path}'.format(
-            uri='http://localhost',
+        client_uri = 'http://{host}:{port}{path}'.format(
+            host=host,
             port=port,
             path=proxied_path
         )
@@ -264,27 +264,27 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     # Support all the methods that torando does by default except for GET which
     # is passed to WebSocketHandlerMixin and then to WebSocketHandler.
 
-    async def http_get(self, port, proxy_path=''):
+    async def http_get(self, host, port, proxy_path=''):
         '''Our non-websocket GET.'''
-        return await self.proxy(port, proxy_path)
+        return await self.proxy(host, port, proxy_path)
 
-    def post(self, port, proxy_path=''):
-        return self.proxy(port, proxy_path)
+    def post(self, host, port, proxy_path=''):
+        return self.proxy(host, port, proxy_path)
 
-    def put(self, port, proxy_path=''):
-        return self.proxy(port, proxy_path)
+    def put(self, host, port, proxy_path=''):
+        return self.proxy(host, port, proxy_path)
 
-    def delete(self, port, proxy_path=''):
-        return self.proxy(port, proxy_path)
+    def delete(self, host, port, proxy_path=''):
+        return self.proxy(host, port, proxy_path)
 
-    def head(self, port, proxy_path=''):
-        return self.proxy(port, proxy_path)
+    def head(self, host, port, proxy_path=''):
+        return self.proxy(host, port, proxy_path)
 
-    def patch(self, port, proxy_path=''):
-        return self.proxy(port, proxy_path)
+    def patch(self, host, port, proxy_path=''):
+        return self.proxy(host, port, proxy_path)
 
-    def options(self, port, proxy_path=''):
-        return self.proxy(port, proxy_path)
+    def options(self, host, port, proxy_path=''):
+        return self.proxy(host, port, proxy_path)
 
     def check_xsrf_cookie(self):
         '''
@@ -467,7 +467,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 def setup_handlers(web_app):
     host_pattern = '.*$'
     web_app.add_handlers('.*', [
-        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler)
+        (url_path_join(web_app.settings['base_url'], r'/proxy/(?:([a-z0-9]+(?:[\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})/)?(\d+)(.*)'), LocalProxyHandler)
     ])
 
 # vim: set et ts=4 sw=4:

--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -473,7 +473,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 def setup_handlers(web_app):
     host_pattern = '.*$'
     web_app.add_handlers('.*', [
-        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler)
+        (url_path_join(web_app.settings['base_url'], r'/proxy/(?:([a-z0-9]+(?:[\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6})/)?(\d+)(.*)'), LocalProxyHandler)
     ])
 
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
I've come across situations where it would be useful to proxy to a port on a host other than `localhost`. 

This PR adds an optional hostname option to the proxy url so users can specify things like:

```
/user/jacobtomlinson/lab/proxy/example.com/8080/somepath.html
```

The original format is still valid.

```
/user/jacobtomlinson/lab/proxy/8080/somepath.html
```