### PR TITLE
Make sure binary messages are proxied correctly (fixes #50)

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -130,7 +130,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
             if message is None:
                 self.close()
             else:
-                self.write_message(message, binary=type(message) is bytes)
+                self.write_message(message, binary=isinstance(message, bytes))
 
         def ping_cb(data):
             """
@@ -160,7 +160,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         """
         self._record_activity()
         if hasattr(self, 'ws'):
-            self.ws.write_message(message)
+            self.ws.write_message(message, binary=isinstance(message, bytes))
 
     def on_ping(self, data):
         """


### PR DESCRIPTION
- in on_message(), check if the received message is of type bytes and if so, send it on with binary flag
- change 'message is bytes' to isinstance(message, bytes)