### PR TITLE
record api_last_activity as timezone aware timestamp

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -4,7 +4,6 @@ Authenticated HTTP proxy for Jupyter Notebooks
 Some original inspiration from https://github.com/senko/tornado-proxy
 """
 
-from datetime import datetime
 import inspect
 import socket
 import os
@@ -13,7 +12,7 @@ from urllib.parse import urlunparse, urlparse
 from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, version_info
 
 from notebook.utils import url_path_join
-from notebook.base.handlers import IPythonHandler
+from notebook.base.handlers import IPythonHandler, utcnow
 
 
 class AddSlashHandler(IPythonHandler):
@@ -194,7 +193,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         avoids proxied traffic being ignored by the notebook's
         internal idle-shutdown mechanism
         """
-        self.settings['api_last_activity'] = datetime.utcnow()
+        self.settings['api_last_activity'] = utcnow()
 
 
     @web.authenticated


### PR DESCRIPTION
fixes problems with notebook status api when producing last_activity timestamp.

i.e. in this line https://github.com/jupyter/notebook/blob/4f9a6cbdd81ed26a7979d993766d7223e1c72e5c/notebook/notebookapp.py#L367
when comparing (max(...)) all timestamps it produces a
TypeError: can't compare offset-naive and offset-aware datetimes