### PR TITLE
Allow configuring processes to start be much easier

### DIFF
--- a/nbserverproxy/__init__.py
+++ b/nbserverproxy/__init__.py
@@ -1,4 +1,5 @@
 from .handlers import setup_handlers, SuperviseAndProxyHandler
+from nbserverproxy.config import ServerProxy
 
 # Jupyter Extension points
 def _jupyter_server_extension_paths():
@@ -14,4 +15,10 @@ def _jupyter_nbextension_paths():
     }]
 
 def load_jupyter_server_extension(nbapp):
+    # Set up handlers picked up via config
+    serverproxy = ServerProxy(parent=nbapp)
+    handlers = serverproxy.get_handlers(nbapp.web_app.settings['base_url'])
+    nbapp.web_app.add_handlers('.*', handlers)
+
+    # Set up default handler
     setup_handlers(nbapp.web_app)

--- a/nbserverproxy/__init__.py
+++ b/nbserverproxy/__init__.py
@@ -1,5 +1,5 @@
 from .handlers import setup_handlers, SuperviseAndProxyHandler
-from nbserverproxy.config import ServerProxy
+from nbserverproxy.config import ServerProxy, make_proxyserver_handlers, get_entrypoint_proxy_servers
 
 # Jupyter Extension points
 def _jupyter_server_extension_paths():
@@ -14,11 +14,16 @@ def _jupyter_nbextension_paths():
         "require": "nbserverproxy/main"
     }]
 
+
 def load_jupyter_server_extension(nbapp):
     # Set up handlers picked up via config
+    base_url = nbapp.web_app.settings['base_url']
     serverproxy = ServerProxy(parent=nbapp)
-    handlers = serverproxy.get_handlers(nbapp.web_app.settings['base_url'])
-    nbapp.web_app.add_handlers('.*', handlers)
+    config_handlers = make_proxyserver_handlers(base_url, serverproxy.servers)
+    nbapp.web_app.add_handlers('.*', config_handlers)
+
+    entrypoint_handlers = make_proxyserver_handlers(base_url, get_entrypoint_proxy_servers())
+    nbapp.web_app.add_handlers('.*', entrypoint_handlers)
 
     # Set up default handler
     setup_handlers(nbapp.web_app)

--- a/nbserverproxy/config.py
+++ b/nbserverproxy/config.py
@@ -2,7 +2,7 @@
 Traitlets based configuration for nbserverproxy
 """
 from notebook.utils import url_path_join as ujoin
-from traitlets import Float, Int, Dict
+from traitlets import Dict
 from traitlets.config import Configurable
 from nbserverproxy.handlers import SuperviseAndProxyHandler, AddSlashHandler
 import pkg_resources

--- a/nbserverproxy/config.py
+++ b/nbserverproxy/config.py
@@ -1,0 +1,77 @@
+"""
+Traitlets based configuration for nbserverproxy
+"""
+from notebook.utils import url_path_join as ujoin
+from traitlets import Float, Int, Dict
+from traitlets.config import Configurable
+from nbserverproxy.handlers import SuperviseAndProxyHandler, AddSlashHandler
+
+
+class ServerProxy(Configurable):
+    servers = Dict(
+        {},
+        help="""
+        Dictionary of processes to supervise & proxy.
+
+        Key should be the name of the process. This is also used by default as
+        the URL prefix, and all requests matching this prefix are routed to this process.
+
+        Value should be a dictionary with the following keys:
+          command
+            A list of strings that should be the full command to be executed. If {{port}}  is
+            present, it'll be substituted with the port the process should listen on.
+
+          environment
+            A dictionary of environment variable mappings. {{port}} will be replaced by the port
+            the process should listen on. If not explicitly set, a PORT environment variable will
+            automatically be set.
+
+        """,
+        config=True
+    )
+
+    def _make_serverproxy_handler(self, name):
+        """
+        Create a Tornado handler class for server with this name
+        """
+        proxy_server = self.servers[name]
+
+        # FIXME: Set 'name' properly
+        class _Proxy(SuperviseAndProxyHandler):
+            def _render_template(self, value):
+                args = {
+                    'port': self.port
+                }
+                if type(value) is str:
+                    return value.format(**args)
+                elif type(value) is list:
+                    return [self._render_template(v) for v in value]
+                elif type(value) is dict:
+                    return {
+                        self._render_template(k): self._render_template(v)
+                        for k, v in value.items()
+                    }
+
+            def get_cmd(self):
+                return self._render_template(proxy_server['command'])
+            
+            def get_env(self):
+                return self._render_template(proxy_server.get('environment', {}))
+        
+        return _Proxy
+
+
+    def get_handlers(self, base_url):
+        """
+        Get tornado handlers for registered proxy servers to app
+        """
+        handlers = []
+        for name in self.servers:
+            handlers.append((
+                ujoin(base_url, f'{name}/(.*)'), self._make_serverproxy_handler(name), dict(state={}),
+            ))
+            self.log.debug(f'Adding handler for server {name}')
+            handlers.append((
+                ujoin(base_url, name), AddSlashHandler
+            ))
+        return handlers

--- a/nbserverproxy/config.py
+++ b/nbserverproxy/config.py
@@ -43,7 +43,10 @@ def _make_serverproxy_handler(name, command, environment):
                 return self._render_template(command)
 
         def get_env(self):
-            return self._render_template(environment)
+            if callable(environment):
+                return self._render_template(environment(**self.process_args))
+            else:
+                return self._render_template(environment)
 
     return _Proxy
 
@@ -87,12 +90,16 @@ class ServerProxy(Configurable):
             A list of strings that should be the full command to be executed. If {{port}}  is
             present, it'll be substituted with the port the process should listen on.
 
-            Could also be a callable that takes a single argument - port.
+            Could also be a callable that takes a single argument - port. It should return
+            a dictionary.
 
           environment
             A dictionary of environment variable mappings. {{port}} will be replaced by the port
             the process should listen on. If not explicitly set, a PORT environment variable will
             automatically be set.
+
+            Could also be a callable that takes a single argument - port. It should return
+            a dictionary.
 
         """,
         config=True


### PR DESCRIPTION
- Traitlet based configuration for users to directly
  specify what processes they want to start & proxy
- entrypoint based configuration for users to be able
  to install a package that can specify how processes
  should start